### PR TITLE
Change MatTable imports to deep imports

### DIFF
--- a/projects/mat-table-exporter/src/lib/mat-table-exporter.directive.ts
+++ b/projects/mat-table-exporter/src/lib/mat-table-exporter.directive.ts
@@ -1,5 +1,6 @@
 import { AfterViewInit, Directive, Host, Renderer2, Self, Optional, ViewContainerRef, Input } from '@angular/core';
-import { MatPaginator, MatTableDataSource, MatTable } from '@angular/material';
+import { MatTableDataSource, MatTable } from '@angular/material/table';
+import { MatPaginator } from '@angular/material/paginator';
 import { CdkTableExporter, DataExtractorService, ServiceLocatorService } from 'cdk-table-exporter';
 import { Observable } from 'rxjs';
 @Directive({


### PR DESCRIPTION
Importing from @angular/material is deprecated and does not work in @angular/material version 9. This change needs to happen before anybody can use Angular 9 with this library.